### PR TITLE
Changing the filter name as it has changed in aws

### DIFF
--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -29,7 +29,7 @@ variable "aws_region" {
 
 variable "aws_source_ami_filter_name" {
   type        = string
-  default     = "CentOS 7* x86_64*"
+  default     = "CentOS Linux 7* x86_64*"
   description = "The source AMI filter string. Any filter described by the DescribeImages API documentation is valid. If multiple images match then the latest will be used"
 }
 


### PR DESCRIPTION
Changing the var name for `aws_source_ami_filter_name` to `CentOS Linux 7* x86_64*` as the change has changed in AWS. 